### PR TITLE
basic Nm template engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gemspec
 
 gem 'rake'
 gem 'pry'
+gem 'bson_ext'
+gem 'sanford', :github => "redding/sanford", :branch => "kr-render"
 
 platform :rbx do
   gem 'rubysl'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ require 'sanford-nm'
 
 Sanford.configure do |c|
 
-  c.template_source "/path/to/templates") do |s|
+  c.template_source "/path/to/templates" do |s|
     s.engine 'nm', Sanford::Nm::TemplateEngine
   end
 
@@ -22,6 +22,15 @@ end
 
 Add `.nm` to any template files in your template source path.  Sanford will render their content using Nm when they are rendered.
 
+### Notes
+
+Nm doesn't allow overriding the template scope but instead allows you to pass in data that binds to the template scope as methods.  By default, the scope Sanford renders with (the service handler) will be bound to Nm's scope via the `view` method in templates.  If you want to change this, provide a `'scope_name'` option when registering:
+
+```ruby
+  c.template_source "/path/to/templates" do |s|
+    s.engine 'nm', Sanford::Nm::TemplateEngine, 'scope_name' => 'service_handler'
+  end
+```
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/sanford-nm.rb
+++ b/lib/sanford-nm.rb
@@ -1,4 +1,25 @@
+require 'nm'
+require 'sanford/template_engine'
 require "sanford-nm/version"
 
 module Sanford::Nm
+
+  class TemplateEngine < Sanford::TemplateEngine
+
+    DEFAULT_SCOPE_NAME = 'view'
+
+    def nm_source
+      @nm_source ||= Nm::Source.new(self.source_path)
+    end
+
+    def nm_scope_name
+      @nm_scope_name ||= (self.opts['scope_name'] || DEFAULT_SCOPE_NAME)
+    end
+
+    def render(path, scope)
+      self.nm_source.render(path, self.nm_scope_name => scope)
+    end
+
+  end
+
 end

--- a/sanford-nm.gemspec
+++ b/sanford-nm.gemspec
@@ -20,4 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.10"])
 
+  gem.add_dependency("sanford", ["~> 0.9"])
+  gem.add_dependency("nm")
+
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,4 +7,7 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
+require 'pathname'
+TEST_SUPPORT_PATH = Pathname.new(File.expand_path('../support', __FILE__))
+
 require 'test/support/factory'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,4 +3,12 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.template_json_rendered(scope)
+    { 'thing' => {
+        'id' => scope.identifier,
+        'name' => scope.name
+      }
+    }
+  end
+
 end

--- a/test/support/template.json.nm
+++ b/test/support/template.json.nm
@@ -1,0 +1,4 @@
+node('thing') {
+  node('id', view.identifier)
+  node('name', view.name)
+}

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -1,0 +1,50 @@
+require 'assert'
+require 'sanford-nm'
+
+require 'nm/source'
+require 'sanford/template_engine'
+
+class Sanford::Nm::TemplateEngine
+
+  class UnitTests < Assert::Context
+    desc "Sanford::Nm::TemplateEngine"
+    setup do
+      @engine = Sanford::Nm::TemplateEngine.new({
+        'source_path' => TEST_SUPPORT_PATH
+      })
+    end
+    subject{ @engine }
+
+    should have_imeths :nm_source, :nm_scope_name
+
+    should "be a Sanford template engine" do
+      assert_kind_of Sanford::TemplateEngine, subject
+      assert_respond_to 'render', subject
+    end
+
+    should "memoize its Nm source" do
+      assert_kind_of Nm::Source, subject.nm_source
+      assert_equal subject.source_path, subject.nm_source.root
+      assert_same subject.nm_source, subject.nm_source
+    end
+
+    should "use 'view' as the scope name by default" do
+      assert_equal 'view', subject.nm_scope_name
+    end
+
+    should "allow custom scope names" do
+      scope_name = Factory.string
+      engine = Sanford::Nm::TemplateEngine.new('scope_name' => scope_name)
+      assert_equal scope_name, engine.nm_scope_name
+    end
+
+    should "render nm template files" do
+      thing = OpenStruct.new(:identifier => Factory.integer, :name => Factory.string)
+      exp = Factory.template_json_rendered(thing)
+
+      assert_equal exp, subject.render('template.json', thing)
+    end
+
+  end
+
+end


### PR DESCRIPTION
This engine renders the given path, in the source path, using Nm.
Sanford then takes the rendered template data and serializes it to
BSON as needed.

This engine memoizes the Nm source and binds to an overridable
scope name method, 'view'.

This should be all that is needed to have a working sanford Nm
template engine.

Related to redding/sanford#85.

@jcredding ready for review.
