### PR TITLE
update to support locals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'rake'
 gem 'pry'
 gem 'bson_ext'
-gem 'sanford', :github => "redding/sanford", :branch => "kr-render"
+gem 'sanford', :github => "redding/sanford", :branch => "master"
 
 platform :rbx do
   gem 'rubysl'

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Add `.nm` to any template files in your template source path.  Sanford will rend
 
 ### Notes
 
-Nm doesn't allow overriding the template scope but instead allows you to pass in data that binds to the template scope as methods.  By default, the scope Sanford renders with (the service handler) will be bound to Nm's scope via the `view` method in templates.  If you want to change this, provide a `'scope_name'` option when registering:
+Nm doesn't allow overriding the template scope but instead allows you to pass in data that binds to the template scope as methods.  By default, the service handler will be bound to Nm's scope via the `view` method in templates.  If you want to change this, provide a `'handler_local'` option when registering:
 
 ```ruby
   c.template_source "/path/to/templates" do |s|
-    s.engine 'nm', Sanford::Nm::TemplateEngine, 'scope_name' => 'service_handler'
+    s.engine 'nm', Sanford::Nm::TemplateEngine, 'handler_local' => 'service_handler'
   end
 ```
 ## Installation

--- a/lib/sanford-nm.rb
+++ b/lib/sanford-nm.rb
@@ -6,18 +6,24 @@ module Sanford::Nm
 
   class TemplateEngine < Sanford::TemplateEngine
 
-    DEFAULT_SCOPE_NAME = 'view'
+    DEFAULT_HANDLER_LOCAL = 'view'
 
     def nm_source
       @nm_source ||= Nm::Source.new(self.source_path)
     end
 
-    def nm_scope_name
-      @nm_scope_name ||= (self.opts['scope_name'] || DEFAULT_SCOPE_NAME)
+    def nm_handler_local
+      @nm_handler_local ||= (self.opts['handler_local'] || DEFAULT_HANDLER_LOCAL)
     end
 
-    def render(path, scope)
-      self.nm_source.render(path, self.nm_scope_name => scope)
+    def render(path, service_handler, locals)
+      self.nm_source.render(path, render_locals(service_handler, locals))
+    end
+
+    private
+
+    def render_locals(service_handler, locals)
+      { self.nm_handler_local => service_handler }.merge(locals)
     end
 
   end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,10 +3,11 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
-  def self.template_json_rendered(scope)
+  def self.template_json_rendered(service_handler, locals)
     { 'thing' => {
-        'id' => scope.identifier,
-        'name' => scope.name
+        'id' => service_handler.identifier,
+        'name' => service_handler.name,
+        'local1' => locals['local1']
       }
     }
   end

--- a/test/support/template.json.nm
+++ b/test/support/template.json.nm
@@ -1,4 +1,5 @@
 node('thing') {
   node('id', view.identifier)
   node('name', view.name)
+  node('local1', local1)
 }

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -15,7 +15,7 @@ class Sanford::Nm::TemplateEngine
     end
     subject{ @engine }
 
-    should have_imeths :nm_source, :nm_scope_name
+    should have_imeths :nm_source, :nm_handler_local
 
     should "be a Sanford template engine" do
       assert_kind_of Sanford::TemplateEngine, subject
@@ -28,21 +28,25 @@ class Sanford::Nm::TemplateEngine
       assert_same subject.nm_source, subject.nm_source
     end
 
-    should "use 'view' as the scope name by default" do
-      assert_equal 'view', subject.nm_scope_name
+    should "use 'view' as the handler local name by default" do
+      assert_equal 'view', subject.nm_handler_local
     end
 
-    should "allow custom scope names" do
-      scope_name = Factory.string
-      engine = Sanford::Nm::TemplateEngine.new('scope_name' => scope_name)
-      assert_equal scope_name, engine.nm_scope_name
+    should "allow custom handler local names" do
+      handler_local = Factory.string
+      engine = Sanford::Nm::TemplateEngine.new('handler_local' => handler_local)
+      assert_equal handler_local, engine.nm_handler_local
     end
 
     should "render nm template files" do
-      thing = OpenStruct.new(:identifier => Factory.integer, :name => Factory.string)
-      exp = Factory.template_json_rendered(thing)
+      service_handler = OpenStruct.new({
+        :identifier => Factory.integer,
+        :name => Factory.string
+      })
+      locals = { 'local1' => Factory.string }
+      exp = Factory.template_json_rendered(service_handler, locals)
 
-      assert_equal exp, subject.render('template.json', thing)
+      assert_equal exp, subject.render('template.json', service_handler, locals)
     end
 
   end


### PR DESCRIPTION
Sanford's engine api now takes locals.  This updates the engine to
honor locals that are passed to it.

This also updates the handling of the passed service handler.  This
is no longer referred to generically as "scope" but instead specifically
as "service handler".  This option to override the handler local
name has also been updated to better intend its purpose.

This just makes the engine compatible with the latest Sanford engine
API.

@jcredding ready for review.
