### PR TITLE
add Sanfod logger as a default local on all template renders

### DIFF
--- a/lib/sanford-nm.rb
+++ b/lib/sanford-nm.rb
@@ -6,14 +6,21 @@ module Sanford::Nm
 
   class TemplateEngine < Sanford::TemplateEngine
 
-    DEFAULT_HANDLER_LOCAL = 'view'
+    DEFAULT_HANDLER_LOCAL = 'view'.freeze
+    DEFAULT_LOGGER_LOCAL  = 'logger'.freeze
 
     def nm_source
-      @nm_source ||= Nm::Source.new(self.source_path)
+      @nm_source ||= Nm::Source.new(self.source_path, {
+        self.nm_logger_local => self.logger
+      })
     end
 
     def nm_handler_local
       @nm_handler_local ||= (self.opts['handler_local'] || DEFAULT_HANDLER_LOCAL)
+    end
+
+    def nm_logger_local
+      @nm_logger_local ||= (self.opts['logger_local'] || DEFAULT_LOGGER_LOCAL)
     end
 
     def render(path, service_handler, locals)

--- a/sanford-nm.gemspec
+++ b/sanford-nm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.12"])
 
-  gem.add_dependency("sanford", ["~> 0.10"])
-  gem.add_dependency("nm")
+  gem.add_dependency("sanford", ["~> 0.12"])
+  gem.add_dependency("nm",      ["~> 0.4"])
 
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,11 +3,12 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
-  def self.template_json_rendered(service_handler, locals)
+  def self.template_json_rendered(engine, service_handler, locals)
     { 'thing' => {
         'id' => service_handler.identifier,
         'name' => service_handler.name,
-        'local1' => locals['local1']
+        'local1' => locals['local1'],
+        'logger' => engine.logger.to_s
       }
     }
   end

--- a/test/support/template.json.nm
+++ b/test/support/template.json.nm
@@ -2,4 +2,5 @@ node('thing') {
   node('id', view.identifier)
   node('name', view.name)
   node('local1', local1)
+  node('logger', logger.to_s)
 }

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -15,7 +15,8 @@ class Sanford::Nm::TemplateEngine
     end
     subject{ @engine }
 
-    should have_imeths :nm_source, :nm_handler_local, :render
+    should have_imeths :nm_source, :nm_handler_local, :nm_logger_local
+    should have_imeths :render
 
     should "be a Sanford template engine" do
       assert_kind_of Sanford::TemplateEngine, subject
@@ -37,13 +38,23 @@ class Sanford::Nm::TemplateEngine
       assert_equal handler_local, engine.nm_handler_local
     end
 
+    should "use 'logger' as the logger local name by default" do
+      assert_equal 'logger', subject.nm_logger_local
+    end
+
+    should "allow custom logger local names" do
+      logger_local = Factory.string
+      engine = Sanford::Nm::TemplateEngine.new('logger_local' => logger_local)
+      assert_equal logger_local, engine.nm_logger_local
+    end
+
     should "render nm template files" do
       service_handler = OpenStruct.new({
         :identifier => Factory.integer,
         :name => Factory.string
       })
       locals = { 'local1' => Factory.string }
-      exp = Factory.template_json_rendered(service_handler, locals)
+      exp = Factory.template_json_rendered(subject, service_handler, locals)
 
       assert_equal exp, subject.render('template.json', service_handler, locals)
     end


### PR DESCRIPTION
This is so the logger is available from the templates.  This uses
the latest Sanford, which provides the logger to the engine, and
follows the pattern of deas-nm.

@jcredding ready for review.  I'll need to roll a version of Sanford before merging, FYI.
