### PR TITLE
update to the latest Nm; expose the new source `:cache` option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ gem 'bson_ext'
 platform :rbx do
   gem 'rubysl'
 end
+
+gem 'nm', :path => "/Users/kelly/projects/redding/nm"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Nm doesn't allow overriding the template scope but instead allows you to pass in
   end
 ```
 
+Nm doesn't cache templates by default.  To enable caching, pass a `'cache'` option when registering:
+
+```ruby
+  c.template_source "/path/to/templates" do |s|
+    s.engine 'nm', Sanford::Nm::TemplateEngine, 'cache' => true
+  end
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/sanford-nm.rb
+++ b/lib/sanford-nm.rb
@@ -11,7 +11,8 @@ module Sanford::Nm
 
     def nm_source
       @nm_source ||= Nm::Source.new(self.source_path, {
-        self.nm_logger_local => self.logger
+        :cache  => self.opts['cache'],
+        :locals => { self.nm_logger_local => self.logger }
       })
     end
 

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -38,6 +38,11 @@ class Sanford::Nm::TemplateEngine
       assert_equal handler_local, engine.nm_handler_local
     end
 
+    should "pass any given cache option to the Nm source" do
+      engine = Sanford::Nm::TemplateEngine.new('cache' => true)
+      assert_kind_of Hash, engine.nm_source.cache
+    end
+
     should "use 'logger' as the logger local name by default" do
       assert_equal 'logger', subject.nm_logger_local
     end


### PR DESCRIPTION
This allows you to integrate the engine and tell Nm to cache templates.

@jcredding ready for review.