### PR TITLE
Pass sanford template engine ext to nm source

### DIFF
--- a/lib/sanford-nm.rb
+++ b/lib/sanford-nm.rb
@@ -12,6 +12,7 @@ module Sanford::Nm
     def nm_source
       @nm_source ||= Nm::Source.new(self.source_path, {
         :cache  => self.opts['cache'],
+        :ext    => self.opts['ext'],
         :locals => { self.nm_logger_local => self.logger }
       })
     end

--- a/sanford-nm.gemspec
+++ b/sanford-nm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.15.1"])
 
-  gem.add_dependency("sanford", ["~> 0.16.1"])
-  gem.add_dependency("nm",      ["~> 0.5.1"])
+  gem.add_dependency("sanford", ["~> 0.17.0"])
+  gem.add_dependency("nm",      ["~> 0.5.2"])
 
 end

--- a/test/support/template.json.aaa
+++ b/test/support/template.json.aaa
@@ -1,0 +1,4 @@
+# This files is just to provide a conflict when rendering. If sanford-nm isn't
+# passing an extension down to nm then nm will try and render this file which
+# will error.
+raise "oops - trying to render wrong template"

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -10,7 +10,8 @@ class Sanford::Nm::TemplateEngine
     desc "Sanford::Nm::TemplateEngine"
     setup do
       @engine = Sanford::Nm::TemplateEngine.new({
-        'source_path' => TEST_SUPPORT_PATH
+        'source_path' => TEST_SUPPORT_PATH,
+        'ext'         => 'nm'
       })
     end
     subject{ @engine }
@@ -43,6 +44,12 @@ class Sanford::Nm::TemplateEngine
       assert_kind_of Hash, engine.nm_source.cache
     end
 
+    should "pass any given ext option to the Nm source" do
+      ext = Factory.string
+      engine = Sanford::Nm::TemplateEngine.new('ext' => ext)
+      assert_equal ".#{ext}", engine.nm_source.ext
+    end
+
     should "use 'logger' as the logger local name by default" do
       assert_equal 'logger', subject.nm_logger_local
     end
@@ -56,11 +63,10 @@ class Sanford::Nm::TemplateEngine
     should "render nm template files" do
       service_handler = OpenStruct.new({
         :identifier => Factory.integer,
-        :name => Factory.string
+        :name       => Factory.string
       })
       locals = { 'local1' => Factory.string }
       exp = Factory.template_json_rendered(subject, service_handler, locals)
-
       assert_equal exp, subject.render('template.json', service_handler, locals)
     end
 


### PR DESCRIPTION
This updates the template engine to pass its ext to nm source. The
template engine ext is set by sanford when the engine is
registered. This makes it so nm will use templates with the
extension that was used when registering the engine with sanford.
This is the expected behavior and avoids confusion with nm randomly
not using a template that matches the registered extension.

This is part of fixing an issue with sanford not rendering the
expected nm template. This is because the nm engine no longer
forced templates extension to be `nm` (see redding/nm#16). By not
expecting an extension, the nm engine can't pick the correct file
as the template if there are multiple files with the same name
except for their extensions. For example, a common pattern is to
name a handler file and the template the same only the handler will
have `.rb` for its extension and the template would use `.nm`. In
this scenario, it's possible for the nm engine to try and use the
ruby file as its template. Nm is being updated to use a custom
extension (the one sanford-nm will now pass to it) to address this
issue (redding/nm#17).

@kellyredding - Ready for review.